### PR TITLE
Fix bundling bug in Python 3.7

### DIFF
--- a/python/circuitsvis/utils/render.py
+++ b/python/circuitsvis/utils/render.py
@@ -86,7 +86,10 @@ def bundle_source(dev_mode: bool = True) -> None:
     # Copy files to python dist directory
     react_dist = REACT_DIR / "dist"
     python_dist = Path(__file__).parent.parent / "dist"
-    shutil.copytree(react_dist, python_dist, dirs_exist_ok=True)
+    try:
+        shutil.copytree(react_dist, python_dist)
+    except FileExistsError:
+        pass
 
 
 def render_local(react_element_name: str, **kwargs) -> str:

--- a/python/circuitsvis/utils/render.py
+++ b/python/circuitsvis/utils/render.py
@@ -1,6 +1,7 @@
 """Helper functions to build visualizations using HTML/web frameworks."""
 import shutil
 import subprocess
+import os
 from pathlib import Path
 from uuid import uuid4
 
@@ -66,7 +67,11 @@ def install_if_necessary() -> None:
 
 
 def bundle_source(dev_mode: bool = True) -> None:
-    """Bundle up the JavaScript/TypeScript source files"""
+    """Bundle up the JavaScript/TypeScript source files
+
+    Bundles the files together and then also copies them to the Python dist/
+    directory. This allows the Python package to also include these files when
+    it is installed."""
     # Build
     build_command = [
         "yarn",
@@ -83,13 +88,14 @@ def bundle_source(dev_mode: bool = True) -> None:
                    check=True
                    )
 
-    # Copy files to python dist directory
+    # Copy files to python dist directory (overwriting any existing files)
     react_dist = REACT_DIR / "dist"
     python_dist = Path(__file__).parent.parent / "dist"
-    try:
-        shutil.copytree(react_dist, python_dist)
-    except FileExistsError:
-        pass
+    if os.path.exists(python_dist):
+        # Python 3.7 doesn't support the exist_ok argument, so we have to delete
+        # the destination directory first
+        shutil.rmtree(python_dist)
+    shutil.copytree(react_dist, python_dist)
 
 
 def render_local(react_element_name: str, **kwargs) -> str:

--- a/python/circuitsvis/utils/tests/test_render.py
+++ b/python/circuitsvis/utils/tests/test_render.py
@@ -30,6 +30,8 @@ class TestInstallIfNecessary:
 class TestBundleSource:
     def test_runs_without_errors(self):
         bundle_source()
+        # Run twice, to check it doesn't fail if the directory already exists
+        bundle_source()
 
 
 class TestRenderLocal:


### PR DESCRIPTION
Added a hacky fix to shutil.copytree, which led to errors in Python 3.7 as the dirs_exist_ok param is not there. 