### PR TITLE
Fix white text on white background bug

### DIFF
--- a/react/src/utils/getTokenBackgroundColor.ts
+++ b/react/src/utils/getTokenBackgroundColor.ts
@@ -16,8 +16,10 @@ export function getTokenBackgroundColor(
   negativeColor: AnyColor = "red",
   positiveColor: AnyColor = "blue"
 ): Colord {
-  // original_color.mix("white", x) interpolates between original_color and white, with x being the ratio of white. So x=0 is original_color, x=1 is white. Clamp at 0 to avoid negative values.
-  if (value > 0) {
+  // original_color.mix("white", x) interpolates between original_color and
+  // white, with x being the ratio of white. So x=0 is original_color, x=1 is
+  // white. Clamp at 0 to avoid negative values.
+  if (value >= 0) {
     return colord(positiveColor).mix(
       colord("white"),
       Math.min(Math.max(1 - value / max, 0), 1)

--- a/react/src/utils/tests/getTokenBackgroundColor.test.ts
+++ b/react/src/utils/tests/getTokenBackgroundColor.test.ts
@@ -22,4 +22,10 @@ describe("getBackgroundColor", () => {
     const hsl = res.toHsl();
     expect(hsl.l).toBeCloseTo(100);
   });
+
+  it("Check that 0 returns a brightness of 1", () => {
+    // If the brightness is <0.6, the text will be white and invisible
+    const res = getTokenBackgroundColor(0, 0, 1);
+    expect(res.brightness()).toBeCloseTo(1);
+  });
 });


### PR DESCRIPTION
The previous implementation failed to account for tokens with activation values of 0. It would set the token background as dark but completely transparent (and thus with a brightness value of 1). This meant that the token text would be coloured white, and would be invisible on the background