### PR TITLE
Add interactive token attention visualization to `attention_heads`

### DIFF
--- a/python/circuitsvis/attention.py
+++ b/python/circuitsvis/attention.py
@@ -16,7 +16,8 @@ def attention_heads(
     negative_color: Optional[str] = None,
     positive_color: Optional[str] = None,
     mask_upper_tri: Optional[bool] = None,
-    show_tokens: Optional[bool] = True,
+    show_tokens: Optional[bool] = None,
+    match_color: Optional[bool] = None,
 ) -> RenderedHTML:
     """Attention Heads
 
@@ -26,8 +27,8 @@ def attention_heads(
     is then shown in full size.
 
     Args:
-        attention: Attention head activations of the shape [dest_tokens x
-        src_tokens]
+        attention: Attention head activations of the shape [heads x dest_tokens x src_tokens]
+        or [dest_tokens x src_tokens] (will be expanded to single head)
         tokens: List of tokens (e.g. `["A", "person"]`). Must be the same length
         as the list of values.
         max_value: Maximum value. Used to determine how dark the token color is
@@ -43,8 +44,10 @@ def attention_heads(
         mask_upper_tri: Whether or not to mask the upper triangular portion of
         the attention patterns. Should be true for causal attention, false for
         bidirectional attention.
-        attention: Attention head activations of the shape [heads x dest_tokens x src_tokens]
-        or [dest_tokens x src_tokens] (will be expanded to single head)
+        show_tokens: Whether to show interactive token visualization where
+        hovering over tokens shows attention strength to other tokens.
+        match_color: Whether to match colors between attention patterns, token
+        visualization, and head headers for visual consistency.
 
     Returns:
         Html: Attention pattern visualization
@@ -83,6 +86,7 @@ def attention_heads(
         "tokens": tokens,
         "maskUpperTri": mask_upper_tri,
         "showTokens": show_tokens,
+        "matchColor": match_color,
     }
 
     return render(

--- a/python/circuitsvis/attention.py
+++ b/python/circuitsvis/attention.py
@@ -53,21 +53,24 @@ def attention_heads(
         Html: Attention pattern visualization
     """
 
-    # Convert attention to numpy array
+    # Convert attention to numpy array if it's not already
+    attention_np: np.ndarray
     if isinstance(attention, torch.Tensor):
-        attention = attention.detach().cpu().numpy()
-    elif not isinstance(attention, np.ndarray):
-        attention = np.array(attention)
+        attention_np = attention.detach().cpu().numpy()
+    elif isinstance(attention, np.ndarray):
+        attention_np = attention
+    else:
+        attention_np = np.array(attention)
 
     # Ensure attention is 3D (num_heads, dest_len, src_len)
-    if attention.ndim == 2:
-        attention = attention[np.newaxis, :, :]
-    elif attention.ndim != 3:
+    if attention_np.ndim == 2:
+        attention_np = attention_np[np.newaxis, :, :]
+    elif attention_np.ndim != 3:
         raise ValueError(
-            f"Attention tensor must be 2D or 3D, got {attention.ndim}D tensor."
+            f"Attention tensor must be 2D or 3D, got {attention_np.ndim}D tensor."
         )
 
-    num_heads, dest_len, src_len = attention.shape
+    num_heads, dest_len, src_len = attention_np.shape
 
     # Validate token count matches attention dimensions
     if len(tokens) != dest_len or len(tokens) != src_len:
@@ -77,7 +80,7 @@ def attention_heads(
         )
 
     kwargs = {
-        "attention": attention,
+        "attention": attention_np,
         "attentionHeadNames": attention_head_names,
         "maxValue": max_value,
         "minValue": min_value,

--- a/react/src/attention/AttentionHeads.tsx
+++ b/react/src/attention/AttentionHeads.tsx
@@ -37,6 +37,7 @@ export function AttentionHeadsSelector({
   onMouseLeave,
   positiveColor,
   maskUpperTri,
+  matchColor,
   tokens
 }: AttentionHeadsProps & {
   attentionHeadNames: string[];
@@ -90,8 +91,12 @@ export function AttentionHeadsSelector({
                   showAxisLabels={false}
                   maxValue={maxValue}
                   minValue={minValue}
-                  negativeColor={negativeColor}
-                  positiveColor={positiveColor}
+                  negativeColor={matchColor ? undefined : negativeColor}
+                  positiveColor={
+                    matchColor
+                      ? attentionHeadColor(idx, attention.length)
+                      : positiveColor
+                  }
                   maskUpperTri={maskUpperTri}
                 />
               </div>
@@ -118,6 +123,7 @@ export function AttentionHeads({
   positiveColor,
   maskUpperTri = true,
   showTokens = true,
+  matchColor = false,
   tokens
 }: AttentionHeadsProps) {
   // Attention head focussed state
@@ -169,6 +175,7 @@ export function AttentionHeads({
         onMouseLeave={onMouseLeave}
         positiveColor={positiveColor}
         maskUpperTri={maskUpperTri}
+        matchColor={matchColor}
         tokens={tokens}
       />
 
@@ -194,8 +201,12 @@ export function AttentionHeads({
               attention={attention[focused]}
               maxValue={maxValue}
               minValue={minValue}
-              negativeColor={negativeColor}
-              positiveColor={positiveColor}
+              negativeColor={matchColor ? undefined : negativeColor}
+              positiveColor={
+                matchColor
+                  ? attentionHeadColor(focused, attention.length)
+                  : positiveColor
+              }
               zoomed={true}
               maskUpperTri={maskUpperTri}
               tokens={tokens}
@@ -334,6 +345,15 @@ export interface AttentionHeadsProps {
    * @default true
    */
   showTokens?: boolean;
+
+  /**
+   * Match colors
+   *
+   * Whether to match colors between attention patterns, token visualization, and head headers for visual consistency.
+   *
+   * @default true
+   */
+  matchColor?: boolean;
 
   /**
    * List of tokens


### PR DESCRIPTION
Addresses #98 

The `attention_heads` function now has an option `show_token` (default: `True`) that displays the tokens and their attention for the selected attention head. 

Additionally, I added a `match_color` argument that causes the attention pattern visualization to have the same color as the pattern preview, the label for the attention head and the token attention visualization (see image):
<img width="1150" height="1062" alt="grafik" src="https://github.com/user-attachments/assets/99d6c6ce-dbf4-4333-a38a-7c02e563ba66" />
